### PR TITLE
Treat Namecoin to non-Namecoin CNAME as insecure

### DIFF
--- a/ncdomain/convert.go
+++ b/ncdomain/convert.go
@@ -259,6 +259,12 @@ func (v *Value) appendAlias(out []dns.RR, suffix, apexSuffix string) ([]dns.RR, 
 		if !ok {
 			return out, fmt.Errorf("bad alias")
 		}
+
+		qn, err := redirectInsecure(qn, suffix, apexSuffix)
+		if err != nil {
+			return out, err
+		}
+
 		out = append(out, &dns.CNAME{
 			Hdr: dns.RR_Header{
 				Name:   suffix,
@@ -279,6 +285,12 @@ func (v *Value) appendTranslate(out []dns.RR, suffix, apexSuffix string) ([]dns.
 		if !ok {
 			return out, fmt.Errorf("bad translate")
 		}
+
+		qn, err := redirectInsecure(qn, suffix, apexSuffix)
+		if err != nil {
+			return out, err
+		}
+
 		out = append(out, &dns.DNAME{
 			Hdr: dns.RR_Header{
 				Name:   suffix,
@@ -291,6 +303,43 @@ func (v *Value) appendTranslate(out []dns.RR, suffix, apexSuffix string) ([]dns.
 	}
 
 	return out, nil
+}
+
+func redirectInsecure(qn, suffix, apexSuffix string) (string, error) {
+	subInput, baseInput, rootInput, err := util.SplitDomainByFloatingAnchor(suffix, "bit")
+	if err != nil {
+		return "", err
+	}
+
+	_, _, rootOutput, errOutput := util.SplitDomainByFloatingAnchor(qn, "bit")
+
+	// CNAME/DNAME from Namecoin to non-Namecoin isn't secure since it would trust the ICANN root.
+	insecureAllowed := strings.Contains(apexSuffix + ".", ".bit._insecure_bit.")
+	isSecure := (errOutput == nil) && (rootInput == rootOutput)
+
+	if ! insecureAllowed && ! isSecure {
+		// redirect to the insecure equivalent
+
+		// "a.b.c.d.bit.x.y.z." -> subInput="a.b.c", baseInput="d", rootInput="bit.x.y.z"
+
+		bit, afterBit := util.SplitDomainTail(rootInput)
+		// "a.b.c.d.bit.x.y.z." -> bit="bit", afterBit="x.y.z"
+
+		insecure := bit + "." + "_insecure_bit" + "."
+		if afterBit != "" {
+			insecure = insecure + afterBit + "."
+		}
+		if baseInput != "" {
+			insecure = baseInput + "." + insecure
+		}
+		if subInput != "" {
+			insecure = subInput + "." + insecure
+		}
+
+		return insecure, nil
+	}
+
+	return qn, nil
 }
 
 func (v *Value) RRsRecursive(out []dns.RR, suffix, apexSuffix string) ([]dns.RR, error) {


### PR DESCRIPTION
The DNS by design assumes that the ICANN root, registries, and registrars are generally trustworthy.  As such, CNAME records in the DNS can delegate trust to a name, but not to a key.  This assumption, however, doesn't hold in the case of Namecoin, which by design does not trust the ICANN root or any other part of the DNS naming system.

There's not really a good way to convey this difference in trust assumptions to DNSSEC software like Unbound.  This PR picks what I think is probably the least bad way.  It implements a domain suffix `bit._insecure_bit.`, which mirrors `bit.` but is intentionally not trusted by DNSSEC software.  Any CNAME record in a `.bit` domain that points to a DNS name is rewritten to point to the corresponding `.bit._insecure_bit` domain, which in turn points to the DNS name.  The effect is that DNSSEC validators will see an insecure zone along the chain from the `.bit` name to the DNS name, and will therefore consider such CNAME records to be insecure.  This does **not** make the records appear to be bogus.  In practice, this means that applications that don't require DNSSEC will work fine (e.g. A and AAAA records), but applications that do require DNSSEC (e.g. TLSA and SSHFP records) will refuse to accept these records.  Users who want to safely delegate to something outside of Namecoin have 2 main options:

1. CNAME `example.bit`, but don't CNAME `_443._tcp.example.bit`.
2. Use NS+DS instead of CNAME.

It should be noted that the intention of this feature is **not** to prevent name owners from being malicious or from misconfiguring things in highly inventive ways.  There will always be ways to misconfigure a system to make it insecure.  The intention is to remove a common, easily identifiable footgun, similar to how most web browsers treat anonymous DH ciphersuites, SSLv3, MD5 signature hashes, and Debian-bugged public keys as insecure.

Open questions:

* Is there a less annoying way to convey this difference in trust assumptions to DNS software?
* Will ICANN and/or IETF be pissed off that we're squatting on the `._bit_insecure` TLD?
* Will the use of underscores in the intermediate names break any common software?
* Should something similar be done for SRV/MX records that point to DNS names?
* Are there any real-world use cases that this breaks, which we want to support?  It basically breaks DNAME.  AFAIK DNAME is really rare in real-world deployment.  Should we add a shorthand JSON field that generates CNAME records for a subset of subdomains (e.g. generating CNAME records for everything that doesn't start with `_port._protocol`)?
* For that matter, do we want to support the use case of delegating trust to the ICANN root key?  I think this is a really bad idea whose primary result will be footgunning.  Is there a legit reason I haven't thought of for supporting this use case?  If so, what's the best way to support it without being a footgun factory?