### PR TITLE
Travis CI: Add Go 1.8.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.7.1
+  - 1.8.3
 
 addons:
   apt:


### PR DESCRIPTION
This is the version currently used by Tor's build system; grep https://gitweb.torproject.org/builders/tor-browser-bundle.git/tree/gitian/versions for `GO_VER`.