### PR TITLE
Fix Travis environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ after_success:
   - source ./.travis/after_success
 
 env:
-  # GITHUB_TOKEN for automatic releases
-  - secure: "at1oJs7ib7glx3W+zk+OkT041LdknVXirIhN403CIihVUrlOhODY7yCTgvF4Rk0jYBJiT35Q2qxpgfWF2qGnsNsQmjG3ydDWQDCepDc/CgXfLyoiSTJK5vTK72dYWTVsBTycXbj1CbSy2X2ah/KWjc4RcgZ67ER7mDpRU5nFeow="
-  # Set this to the Go version to use for releases (must appear in version list above).
-  - RELEASE_GO_VERSION="1.8"
+  global:
+    # GITHUB_TOKEN for automatic releases
+    - secure: "at1oJs7ib7glx3W+zk+OkT041LdknVXirIhN403CIihVUrlOhODY7yCTgvF4Rk0jYBJiT35Q2qxpgfWF2qGnsNsQmjG3ydDWQDCepDc/CgXfLyoiSTJK5vTK72dYWTVsBTycXbj1CbSy2X2ah/KWjc4RcgZ67ER7mDpRU5nFeow="
+    # Set this to the Go version to use for releases (must appear in version list above).
+    - RELEASE_GO_VERSION="1.8"


### PR DESCRIPTION
Whoops, needs to be under `global:` or it gets interpreted as a build
matrix. @JeremyRand