### PR TITLE
Upgrade to Go 1.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ env:
     # GITHUB_TOKEN for automatic releases
     - secure: "at1oJs7ib7glx3W+zk+OkT041LdknVXirIhN403CIihVUrlOhODY7yCTgvF4Rk0jYBJiT35Q2qxpgfWF2qGnsNsQmjG3ydDWQDCepDc/CgXfLyoiSTJK5vTK72dYWTVsBTycXbj1CbSy2X2ah/KWjc4RcgZ67ER7mDpRU5nFeow="
     # Set this to the Go version to use for releases (must appear in version list above).
-    - RELEASE_GO_VERSION="1.8"
+    - RELEASE_GO_VERSION="1.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
-  - 1.7.1
-  - 1.8.3
+  - 1.9
 
 addons:
   apt:


### PR DESCRIPTION
Depends on #64.  Should not be merged until The Tor Project has upgraded their RBM descriptor to Go 1.9 or higher.