### PR TITLE
Upgrade to Go 1.10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.9
+  - "1.10"
 
 addons:
   apt:

--- a/x509/install.sh
+++ b/x509/install.sh
@@ -5,3 +5,13 @@ shopt -s failglob
 
 cp -a $(go env GOROOT)/src/crypto/x509/* ./
 rm ./x509_test.go
+
+# The following code is utterly horrifying.  I can't find a better way to do it.  :(
+mkdir -p ${GOPATH}/src/vendor/golang.org/
+cp -R $(go env GOROOT)/src/vendor/golang_org/* ${GOPATH}/src/vendor/golang.org/
+# h/t to https://www.cyberciti.biz/faq/unix-linux-replace-string-words-in-many-files/
+OLD_PACKAGE='"golang_org/x/crypto/cryptobyte'
+OLD_PACKAGE="${OLD_PACKAGE//\//\\/}"
+NEW_PACKAGE='"golang.org/x/crypto/cryptobyte'
+NEW_PACKAGE="${NEW_PACKAGE//\//\\/}"
+sed -i "s/${OLD_PACKAGE}/${NEW_PACKAGE}/g" ./*.go ${GOPATH}/src/vendor/golang.org/x/crypto/cryptobyte/*.go

--- a/x509/x509_splice.go
+++ b/x509/x509_splice.go
@@ -41,7 +41,7 @@ import (
 	//"strings"
 	//"time"
 	//"unicode/utf8"
-
+	//
 	//"golang_org/x/crypto/cryptobyte"
 	//cryptobyte_asn1 "golang_org/x/crypto/cryptobyte/asn1"
 )

--- a/x509/x509_splice.go
+++ b/x509/x509_splice.go
@@ -6,7 +6,7 @@
 // This code is modified from the stock CreateCertificate to use a
 // pre-existing signature.
 
-// Last rebased on Go 1.9
+// Last rebased on Go 1.10
 // Remove all content between "import" and "CreateCertificate" in original.
 // Remove all content after "CreateCertificate" in original.
 //go:generate bash install.sh
@@ -36,11 +36,17 @@ import (
 	//"io"
 	//"math/big"
 	//"net"
+	//"net/url"
 	//"strconv"
+	//"strings"
 	//"time"
+	//"unicode/utf8"
+
+	//"golang_org/x/crypto/cryptobyte"
+	//cryptobyte_asn1 "golang_org/x/crypto/cryptobyte/asn1"
 )
 
-// CreateCertificate creates a new certificate based on a template.
+// CreateCertificate creates a new X.509v3 certificate based on a template.
 // The following members of template are used: AuthorityKeyId,
 // BasicConstraintsValid, DNSNames, ExcludedDNSDomains, ExtKeyUsage,
 // IsCA, KeyUsage, MaxPathLen, MaxPathLenZero, NotAfter, NotBefore,
@@ -104,7 +110,7 @@ func CreateCertificateWithSplicedSignature(template, parent *Certificate) (cert 
 		authorityKeyId = parent.SubjectKeyId
 	}
 
-	extensions, err := buildExtensions(template, authorityKeyId)
+	extensions, err := buildExtensions(template, bytes.Equal(asn1Subject, emptyASN1Subject), authorityKeyId)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Depends on #65 .  Should not be merged until The Tor Project has upgraded their RBM descriptor to Go 1.10 or higher.