### PR TITLE
Travis: Disable "test" and "aligncheck" static analyzers in both critical and non-critical steps

### DIFF
--- a/.travis/script
+++ b/.travis/script
@@ -17,6 +17,7 @@ gometalinter.v1 --install
 # aligncheck is disabled because of these comments:
 # * https://www.reddit.com/r/golang/comments/3lahav/aligncheck_helps_to_find_inefficiently_packed/cv4u4lg/
 # * https://www.reddit.com/r/golang/comments/3lahav/aligncheck_helps_to_find_inefficiently_packed/cv5wnom/
+# test is disabled because we already do tests earlier in the script.
 # The --exclude line disables warnings on the portion of x509 that is copied
 # verbatim from the Go standard library.
 echo ""
@@ -34,6 +35,7 @@ gometalinter.v1 --enable-all \
 --disable=lll \
 --disable=misspell \
 --disable=staticcheck \
+--disable=test \
 --disable=unconvert \
 --disable=unparam \
 --disable=unused \

--- a/.travis/script
+++ b/.travis/script
@@ -48,6 +48,8 @@ STATICRESULT1=$?
 echo ""
 echo "gometalinter non-critical (warnings expected):"
 gometalinter.v1 --enable-all \
+--disable=aligncheck \
+--disable=test \
 --concurrency=3 \
 --deadline=10m \
 --exclude='^x509/([a-wy-z]|x509.go|x509_[a-rt-z])' \


### PR DESCRIPTION
Should fix one of the Travis failures.