### PR TITLE
Temporarily disable netbsd/arm builds.

### DIFF
--- a/.travis/script
+++ b/.travis/script
@@ -70,7 +70,7 @@ gox -parallel=$GOX_PARA -cgo -osarch 'linux/386 linux/amd64' -output "$GOPATH/re
 RESULT1=$?
 
 # non-cgo crosscompile
-gox -parallel=$GOX_PARA -osarch 'darwin/386 darwin/amd64 linux/arm linux/arm64 linux/ppc64 linux/ppc64le freebsd/386 freebsd/amd64 freebsd/arm openbsd/386 openbsd/amd64 netbsd/386 netbsd/amd64 netbsd/arm dragonfly/amd64 solaris/amd64 windows/386 windows/amd64' -output "$GOPATH/releasing/idist/ncdns-$TRAVIS_TAG-{{.OS}}_{{.Arch}}/bin/{{.Dir}}" $REPOS
+gox -parallel=$GOX_PARA -osarch 'darwin/386 darwin/amd64 linux/arm linux/arm64 linux/ppc64 linux/ppc64le freebsd/386 freebsd/amd64 freebsd/arm openbsd/386 openbsd/amd64 netbsd/386 netbsd/amd64 dragonfly/amd64 solaris/amd64 windows/386 windows/amd64' -output "$GOPATH/releasing/idist/ncdns-$TRAVIS_TAG-{{.OS}}_{{.Arch}}/bin/{{.Dir}}" $REPOS
 RESULT2=$?
 
 echo cgo crosscompile exited with code $RESULT1


### PR DESCRIPTION
Due to https://github.com/miekg/dns/issues/655 ; this should fix Travis fails.  This will be reverted when that issue is fixed.