### PR TITLE
Travis: disable gochecknoglobals as critical.

### DIFF
--- a/.travis/script
+++ b/.travis/script
@@ -27,6 +27,7 @@ gometalinter.v2 --enable-all \
 --disable=dupl \
 --disable=errcheck \
 --disable=gas \
+--disable=gochecknoglobals \
 --disable=gocyclo \
 --disable=goimports \
 --disable=golint \


### PR DESCRIPTION
The gochecknoglobals is newly added to gometalinter, and it's breaking the build right now.  We should disable it until we've evaluated whether the issues it flags are significant.