### PR TITLE
Support tlsrestrictnsssync

### DIFF
--- a/.travis/script
+++ b/.travis/script
@@ -32,6 +32,7 @@ gometalinter.v2 --enable-all \
 --disable=gocyclo \
 --disable=gofmt \
 --disable=golint \
+--disable=gosec \
 --disable=ineffassign \
 --disable=lll \
 --disable=maligned \

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -7,6 +7,7 @@ import "github.com/namecoin/ncdns/namecoin"
 import "github.com/namecoin/ncdns/util"
 import "github.com/namecoin/ncdns/ncdomain"
 import "github.com/namecoin/ncdns/tlshook"
+import "github.com/namecoin/tlsrestrictnss/tlsrestrictnsssync"
 import "github.com/hlandau/xlog"
 import "sync"
 import "fmt"
@@ -107,6 +108,11 @@ func convertEmail(email string) (string, error) {
 // Do low-level queries against an abstract zone file. This is the per-query
 // entrypoint from madns.
 func (b *Backend) Lookup(qname string) (rrs []dns.RR, err error) {
+	if !tlsrestrictnsssync.IsReady() {
+		err = fmt.Errorf("tlsrestrictnss not ready")
+		return
+	}
+
 	btx := &btx{}
 	btx.b = b
 	btx.qname = qname

--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/namecoin/ncdns/backend"
 	"github.com/namecoin/ncdns/namecoin"
 	"github.com/namecoin/ncdns/tlsoverridefirefox/tlsoverridefirefoxsync"
+	"github.com/namecoin/tlsrestrictnss/tlsrestrictnsssync"
 	"gopkg.in/hlandau/madns.v1"
 )
 
@@ -218,6 +219,11 @@ func (s *Server) Start() error {
 	err := tlsoverridefirefoxsync.Start(s.namecoinConn, s.cfg.CanonicalSuffix)
 	if err != nil {
 		return fmt.Errorf("Couldn't start Firefox override sync: %s", err)
+	}
+
+	err = tlsrestrictnsssync.Start()
+	if err != nil {
+		return fmt.Errorf("Couldn't start tlsrestrictnss sync: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds the ability to automatically re-apply name constraints whenever an NSS application such as Firefox is updated.  Depends on https://github.com/namecoin/tlsrestrictnss/pull/14 .