### PR TITLE
Make Namecoin RPC timeout configurable

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -33,6 +33,9 @@ var log, Log = xlog.New("ncdns.backend")
 type Config struct {
 	NamecoinConn namecoin.Conn
 
+	// Timeout (in milliseconds) for Namecoin RPC requests
+	NamecoinTimeout int
+
 	// Maximum entries to permit in name cache. If zero, a default value is used.
 	CacheMaxEntries int
 
@@ -355,7 +358,7 @@ func (b *Backend) resolveName(name string) (jsonValue string, err error) {
 	select {
 	case <-result:
 		return
-	case <-time.After(1500 * time.Millisecond):
+	case <-time.After(time.Duration(b.cfg.NamecoinTimeout) * time.Millisecond):
 		return "", fmt.Errorf("timeout")
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -46,6 +46,7 @@ type Config struct {
 	NamecoinRPCPassword   string `default:"" usage:"Namecoin RPC password"`
 	NamecoinRPCAddress    string `default:"127.0.0.1:8336" usage:"Namecoin RPC server address"`
 	NamecoinRPCCookiePath string `default:"" usage:"Namecoin RPC cookie path (if set, used instead of password)"`
+	NamecoinRPCTimeout    int    `default:"1500" usage:"Timeout (in milliseconds) for Namecoin RPC requests"`
 	CacheMaxEntries       int    `default:"100" usage:"Maximum name cache entries"`
 	SelfName              string `default:"" usage:"The FQDN of this nameserver. If empty, a pseudo-hostname is generated."`
 	SelfIP                string `default:"127.127.127.127" usage:"The canonical IP address for this service"`
@@ -106,6 +107,7 @@ func New(cfg *Config) (s *Server, err error) {
 
 	b, err := backend.New(&backend.Config{
 		NamecoinConn:         s.namecoinConn,
+		NamecoinTimeout:      cfg.NamecoinRPCTimeout,
 		CacheMaxEntries:      cfg.CacheMaxEntries,
 		SelfIP:               cfg.SelfIP,
 		Hostmaster:           cfg.Hostmaster,


### PR DESCRIPTION
The 1500ms timeout regularly gets hit when using Electrum-NMC over Tor, so being able to configure it seems like a good idea.