### PR TITLE
Disable q and dns-prop279 in Travis

### DIFF
--- a/.travis/script
+++ b/.travis/script
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-travis_retry go get github.com/tcnksm/ghr github.com/mitchellh/gox gopkg.in/alecthomas/gometalinter.v2 github.com/miekg/exdns/q github.com/namecoin/dns-prop279
+# Upstream q is broken, and this also causes dns-prop279 to be broken.
+#travis_retry go get github.com/tcnksm/ghr github.com/mitchellh/gox gopkg.in/alecthomas/gometalinter.v2 github.com/miekg/exdns/q github.com/namecoin/dns-prop279
+travis_retry go get github.com/tcnksm/ghr github.com/mitchellh/gox gopkg.in/alecthomas/gometalinter.v2
 
 go test -v ./...
 RESULT=$?
@@ -69,7 +71,9 @@ mkdir -p "$GOPATH/releasing/idist" "$GOPATH/releasing/dist"
 
 GOX_PARA=3
 
-REPOS="github.com/$TRAVIS_REPO_SLUG/... github.com/miekg/exdns/q github.com/namecoin/dns-prop279/..."
+# Upstream q is broken, and this also causes dns-prop279 to be broken.
+#REPOS="github.com/$TRAVIS_REPO_SLUG/... github.com/miekg/exdns/q github.com/namecoin/dns-prop279/..."
+REPOS="github.com/$TRAVIS_REPO_SLUG/..."
 
 # cgo crosscompile
 gox -parallel=$GOX_PARA -cgo -osarch 'linux/386 linux/amd64' -output "$GOPATH/releasing/idist/ncdns-$TRAVIS_TAG-{{.OS}}_{{.Arch}}/bin/{{.Dir}}" $REPOS


### PR DESCRIPTION
Both of them are broken due to upstream issues.  The upstream breakage should be possible to workaround in rbm when we get around to it, but that's probably not going to happen before the next ncdns release.