### PR TITLE
Add stream isolation (except for namecoind)

### DIFF
--- a/namecoin/namecoin.go
+++ b/namecoin/namecoin.go
@@ -4,7 +4,7 @@ package namecoin
 import (
 	extratypes "github.com/hlandau/ncbtcjsontypes"
 	"github.com/hlandauf/btcjson"
-	"gopkg.in/hlandau/madns.v1/merr"
+	"gopkg.in/hlandau/madns.v2/merr"
 
 	"expvar"
 	"fmt"
@@ -57,8 +57,13 @@ func (nc *Conn) rpcSend(cmd btcjson.Cmd) (btcjson.Reply, error) {
 // Query the Namecoin daemon for a Namecoin domain (e.g. d/example).
 // If the domain exists, returns the value stored in Namecoin, which should be JSON.
 // Note that this will return domain data even if the domain is expired.
-func (nc *Conn) Query(name string) (v string, err error) {
+func (nc *Conn) Query(name string, streamIsolationID string) (v string, err error) {
 	cQueryCalls.Add(1)
+
+	// TODO: Pass stream isolation ID to namecoind, and remove this error
+	if streamIsolationID != "" {
+		return "", fmt.Errorf("Stream isolation ID '%s' is not yet passed to namecoind", streamIsolationID)
+	}
 
 	cmd, err := extratypes.NewNameShowCmd(newID(), name)
 	if err != nil {

--- a/ncdt/ncdt.go
+++ b/ncdt/ncdt.go
@@ -41,7 +41,7 @@ func translateValue(k, v string) (string, error) {
 
 		f = os.NewFile(uintptr(n), "-")
 	} else if len(v) == 1 {
-		return conn.Query(k)
+		return conn.Query(k, "")
 	} else {
 		f, err = os.Open(v)
 	}

--- a/ncdumpzone/ncdumpzone.go
+++ b/ncdumpzone/ncdumpzone.go
@@ -55,7 +55,7 @@ func dumpName(item *extratypes.NameFilterItem, conn namecoin.Conn,
 	}
 
 	getNameFunc := func(k string) (string, error) {
-		return conn.Query(k)
+		return conn.Query(k, "")
 	}
 
 	var errors []error

--- a/server/server.go
+++ b/server/server.go
@@ -14,7 +14,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/namecoin/ncdns/backend"
 	"github.com/namecoin/ncdns/namecoin"
-	"gopkg.in/hlandau/madns.v1"
+	"gopkg.in/hlandau/madns.v2"
 )
 
 var log, Log = xlog.New("ncdns.server")

--- a/server/web.go
+++ b/server/web.go
@@ -140,7 +140,7 @@ func (ws *webServer) handleLookup(rw http.ResponseWriter, req *http.Request) {
 	info.JSONValue = req.FormValue("value")
 	info.Value = strings.Trim(info.JSONValue, " \t\r\n")
 	if info.Value == "" {
-		info.Value, info.ExistenceError = ws.s.namecoinConn.Query(info.NamecoinName)
+		info.Value, info.ExistenceError = ws.s.namecoinConn.Query(info.NamecoinName, "")
 		if info.ExistenceError != nil {
 			return
 		}
@@ -170,7 +170,7 @@ func (ws *webServer) handleLookup(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (ws *webServer) resolveFunc(name string) (string, error) {
-	return ws.s.namecoinConn.Query(name)
+	return ws.s.namecoinConn.Query(name, "")
 }
 
 func (ws *webServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {

--- a/util/util.go
+++ b/util/util.go
@@ -1,7 +1,7 @@
 package util
 
 import "strings"
-import "gopkg.in/hlandau/madns.v1/merr"
+import "gopkg.in/hlandau/madns.v2/merr"
 import "fmt"
 import "regexp"
 import "net/mail"

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -2,7 +2,7 @@ package util_test
 
 import "testing"
 import "github.com/namecoin/ncdns/util"
-import "gopkg.in/hlandau/madns.v1/merr"
+import "gopkg.in/hlandau/madns.v2/merr"
 
 type item struct {
 	input            string


### PR DESCRIPTION
This PR adds the plumbing for stream isolation (from madns to namecoin, without passing the stream ID to namecoind), and stream-isolates the LRU cache.  A follow-up PR will pass the stream ID to namecoind; that's currently blocked on https://github.com/namecoin/ncdns/pull/103 .

Prerequisites:

- [x] Merge https://github.com/hlandau/madns/pull/4
- [x] Merge https://github.com/hlandau/madns/pull/5
- [x] Tag a madns release (with major version 2).
- [x] Replace `madns.v1` dependency with `madns.v2`.
- [x] Tag a madns release (with https://github.com/hlandau/madns/pull/5 included).