### PR TITLE
generate_nmc_cert: Use external x509 package in parent.go

### DIFF
--- a/generate_nmc_cert/parent.go
+++ b/generate_nmc_cert/parent.go
@@ -37,7 +37,7 @@ import (
 	//"strings"
 	"time"
 
-	"github.com/namecoin/ncdns/x509"
+	"github.com/namecoin/x509-signature-splice/x509"
 )
 
 //var (


### PR DESCRIPTION
`parent.go` was accidentally not updated when `x509` moved to an external repo; this is breaking the Travis build.  This PR fixes that.