### PR TITLE
certdehydrate: Fix unit test for Golang issue 40458

### DIFF
--- a/certdehydrate/certdehydrate_test.go
+++ b/certdehydrate/certdehydrate_test.go
@@ -94,9 +94,13 @@ func TestDehydratedCertSignatureInvalid(t *testing.T) {
 		t.Error("Error rehydrating certificate:", err)
 	}
 
+	// Go 1.16+ will error here due to Golang issue #40458.
+	// Earlier Go versions won't notice.
 	derBytes, err := certdehydrate.FillRehydratedCertTemplate(*template, "www2.veclabs.bit")
 	if err != nil {
-		t.Error("Error filling domain into rehydrated certificate template:", err)
+		// The invalid sig was detected by Go 1.16+ like we want.  derBytes is
+		// nil, so we can't proceed, which is fine.
+		return
 	}
 
 	cert, err := x509.ParseCertificate(derBytes)


### PR DESCRIPTION
`CreateCertificate` now checks the resulting signature as of Go 1.16+.  This was confusing our unit test for invalid dehydrated certs, which was expecting to need to verify the cert after the cert was created.