### PR TITLE
readme: specify module path in go mod init command

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,14 +29,14 @@ task:
         - cd ../
         - git clone https://github.com/namecoin/x509-compressed.git
         - cd x509-compressed
-        - go mod init
+        - go mod init github.com/namecoin/x509-compressed
         - go mod tidy
         - go generate ./...
         - go mod tidy
         - go install -v ./...
       fetch_script:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
-        - go mod init
+        - go mod init github.com/"$CIRRUS_REPO_FULL_NAME"
         - go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest -replace github.com/namecoin/x509-compressed=../x509-compressed
         - go mod tidy
   lint_script:
@@ -109,14 +109,14 @@ task:
         - cd ../
         - git clone https://github.com/namecoin/x509-compressed.git
         - cd x509-compressed
-        - go mod init
+        - go mod init github.com/namecoin/x509-compressed
         - go mod tidy
         - go generate ./...
         - go mod tidy
         - go install -v ./...
       fetch_script:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
-        - go mod init
+        - go mod init github.com/"$CIRRUS_REPO_FULL_NAME"
         - go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest -replace github.com/namecoin/x509-compressed=../x509-compressed
         - go mod tidy
         # Get the test suite
@@ -165,14 +165,14 @@ task:
         - cd ../
         - git clone https://github.com/namecoin/x509-compressed.git
         - cd x509-compressed
-        - go mod init
+        - go mod init github.com/namecoin/x509-compressed
         - go mod tidy
         - go generate ./...
         - go mod tidy
         - go install -v ./...
       fetch_script:
         - cd $(go env GOPATH)/src/github.com/"$CIRRUS_REPO_FULL_NAME"
-        - go mod init
+        - go mod init github.com/"$CIRRUS_REPO_FULL_NAME"
         - go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest -replace github.com/namecoin/x509-compressed=../x509-compressed
         - go mod tidy
   build_script:

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Option B: Using Go build commands with Go modules (works on any platform with Ba
 2. Run the following in the ncdns directory to set up Go modules:
    
    ~~~
-   go mod init
+   go mod init github.com/namecoin/ncdns
    go mod edit -replace github.com/coreos/go-systemd=github.com/coreos/go-systemd/v22@latest -replace github.com/namecoin/x509-compressed=../x509-compressed
    go mod tidy
    ~~~


### PR DESCRIPTION
Fixes error:

	go: cannot determine module path for source directory
	/home/redfish/foo/ncdns (outside GOPATH, module path must be
	specified)

Fixes #141