### PR TITLE
CI: Whitelist go.mod replace x509-compressed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ task:
         - go mod tidy
   lint_script:
     - cd $(go env GOPATH)/src/github.com/$CIRRUS_REPO_FULL_NAME/
-    - golangci-lint run --no-config --enable-all --disable gochecknoglobals,gomnd $GOLANGCI_ARGS -v --timeout 5m --out-format json > $CIRRUS_WORKING_DIR/lint-report.json
+    - golangci-lint run --enable-all --disable gochecknoglobals,gomnd $GOLANGCI_ARGS -v --timeout 5m --out-format json > $CIRRUS_WORKING_DIR/lint-report.json
   matrix:
     - name: Go Lint $GOOS New
       env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+linters-settings:
+  goimports:
+    local-prefixes: "github.com/namecoin"
+  gomoddirectives:
+    replace-local: true
+    replace-allow-list:
+      - "github.com/namecoin/x509-compressed"


### PR DESCRIPTION
Fixes a warning from gomoddirectives linter.