### PR TITLE
Web server: use short if syntax

### DIFF
--- a/server/web.go
+++ b/server/web.go
@@ -197,8 +197,7 @@ func clearAllCookies(rw http.ResponseWriter, req *http.Request) {
 }
 
 func webStart(listenAddr string, server *Server) error {
-	err := server.initTemplates()
-	if err != nil {
+	if err := server.initTemplates(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes warning from `ifshort` linter.