### PR TITLE
Cirrus: Fix varnamelen linter warnings

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,7 +59,8 @@ task:
         GOLANGCI_ARGS: "--new-from-rev=HEAD~"
     - name: "Go Lint $GOOS Mandatory$MODULES_NAME"
       env:
-        GOLANGCI_ARGS: "--disable=cyclop,deadcode,errcheck,errorlint,exhaustivestruct,forbidigo,forcetypeassert,funlen,gci,gocognit,gocritic,godot,godox,goerr113,gofumpt,goimports,golint,gosec,gosimple,govet,ineffassign,lll,maligned,nakedret,nestif,nilerr,nlreturn,paralleltest,revive,scopelint,staticcheck,stylecheck,thelper,unconvert,unparam,unused,wastedassign,whitespace,wrapcheck,wsl"
+        # TODO: Re-enable varnamelen after golangci-lint v1.44 is released.
+        GOLANGCI_ARGS: "--disable=cyclop,deadcode,errcheck,errorlint,exhaustivestruct,forbidigo,forcetypeassert,funlen,gci,gocognit,gocritic,godot,godox,goerr113,gofumpt,goimports,golint,gosec,gosimple,govet,ineffassign,lll,maligned,nakedret,nestif,nilerr,nlreturn,paralleltest,revive,scopelint,staticcheck,stylecheck,thelper,unconvert,unparam,unused,varnamelen,wastedassign,whitespace,wrapcheck,wsl"
     - name: "Go Lint $GOOS$MODULES_NAME"
       env:
         GOLANGCI_ARGS: ""

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,3 +6,5 @@ linters-settings:
     replace-allow-list:
       - "github.com/namecoin/x509-compressed"
       - "github.com/coreos/go-systemd"
+  varnamelen:
+    ignore-type-assert-ok: true

--- a/util/util.go
+++ b/util/util.go
@@ -74,7 +74,7 @@ func SplitDomainByFloatingAnchor(qname, anchor string) (subname, basename, rootn
 		// scanning for rootname
 		if v == anchor {
 			if i == 0 {
-				// i is alreay zero, so we have something like bit.x.y.z.
+				// i is already zero, so we have something like bit.x.y.z.
 				rootname = qname
 				return
 			}

--- a/util/util.go
+++ b/util/util.go
@@ -68,20 +68,20 @@ func SplitDomainByFloatingAnchor(qname, anchor string) (subname, basename, rootn
 		return
 	}
 
-	for i := len(parts) - 1; i >= 0; i-- {
-		v := parts[i]
+	for partIndex := len(parts) - 1; partIndex >= 0; partIndex-- {
+		v := parts[partIndex]
 
 		// scanning for rootname
 		if v == anchor {
-			if i == 0 {
-				// i is already zero, so we have something like bit.x.y.z.
+			if partIndex == 0 {
+				// partIndex is already zero, so we have something like bit.x.y.z.
 				rootname = qname
 				return
 			}
 
-			rootname = strings.Join(parts[i:], ".")
-			basename = parts[i-1]
-			subname = strings.Join(parts[0:i-1], ".")
+			rootname = strings.Join(parts[partIndex:], ".")
+			basename = parts[partIndex-1]
+			subname = strings.Join(parts[0:partIndex-1], ".")
 			return
 		}
 	}


### PR DESCRIPTION
Also disable `varnamelen` linter pending an upstream fix so that the Cirrus build stops failing.