### PR TITLE
Use phuslog for logging

### DIFF
--- a/_doc/ncdns.conf.example
+++ b/_doc/ncdns.conf.example
@@ -110,3 +110,12 @@
 ### automatically, you must set the full path to it here manually. Paths will be
 ### interpreted relative to the configuration file.
 #tplpath="../tpl"
+
+
+### Logging (Optional)
+### ------------------
+[xlog]
+
+### Set the minimum log severity. Valid values include "trace", "debug", "info",
+### "notice", "warn", "error", and "critical".
+#severity="NOTICE"

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -7,7 +7,7 @@ import "github.com/namecoin/ncdns/namecoin"
 import "github.com/namecoin/ncdns/util"
 import "github.com/namecoin/ncdns/ncdomain"
 import "github.com/namecoin/ncdns/tlshook"
-import "github.com/hlandau/xlog"
+import "github.com/namecoin/ncdns/logconfig"
 import "sync"
 import "fmt"
 import "net"
@@ -25,7 +25,7 @@ type Backend struct {
 	cfg        Config
 }
 
-var log, Log = xlog.New("ncdns.backend")
+var log = logconfig.New("ncdns.backend")
 
 // Backend configuration.
 type Config struct {
@@ -367,7 +367,9 @@ func (b *Backend) resolveName(name, streamIsolationID string) (jsonValue string,
 	result := make(chan struct{}, 1)
 	go func() {
 		jsonValue, err = b.nc.NameQuery(name, streamIsolationID)
-		log.Errore(err, "failed to query namecoin")
+		if err != nil {
+			log.Error().Err(err).Msg("failed to query namecoin")
+		}
 		result <- struct{}{}
 	}()
 

--- a/cmd/ncdumpzone/ncdumpzone.go
+++ b/cmd/ncdumpzone/ncdumpzone.go
@@ -4,15 +4,15 @@ import (
 	"os"
 
 	"github.com/btcsuite/btcd/rpcclient"
-	"github.com/hlandau/xlog"
 	"gopkg.in/hlandau/easyconfig.v1"
 	"gopkg.in/hlandau/easyconfig.v1/cflag"
 
+	"github.com/namecoin/ncdns/logconfig"
 	"github.com/namecoin/ncdns/namecoin"
 	"github.com/namecoin/ncdns/ncdumpzone"
 )
 
-var log, _ = xlog.New("ncdumpzone-main")
+var log = logconfig.New("ncdumpzone-main")
 
 var (
 	flagGroup   = cflag.NewGroup(nil, "ncdumpzone")
@@ -39,8 +39,10 @@ var config = easyconfig.Configurator{
 func main() {
 	err := config.Parse(nil)
 	if err != nil {
-		log.Fatalf("Couldn't parse configuration: %s", err)
+		log.Fatal().Err(err).Msg("Couldn't parse configuration")
 	}
+
+	logconfig.Init()
 
 	// Connect to local namecoin core RPC server using HTTP POST mode.
 	connCfg := &rpcclient.ConnConfig{
@@ -56,12 +58,12 @@ func main() {
 	// not supported in HTTP POST mode.
 	conn, err = namecoin.New(connCfg, nil)
 	if err != nil {
-		log.Fatalf("Couldn't create RPC client: %s", err)
+		log.Fatal().Err(err).Msg("Couldn't create RPC client")
 	}
 	defer conn.Shutdown()
 
 	err = ncdumpzone.Dump(conn, os.Stdout, formatFlag.Value())
 	if err != nil {
-		log.Fatalf("Couldn't dump zone: %s", err)
+		log.Fatal().Err(err).Msg("Couldn't dump zone")
 	}
 }

--- a/logconfig/logconfig.go
+++ b/logconfig/logconfig.go
@@ -1,0 +1,52 @@
+package logconfig
+
+import (
+	"strings"
+
+	phuslog "github.com/phuslu/log"
+	"gopkg.in/hlandau/easyconfig.v1/cflag"
+)
+
+var (
+	flagGroup       = cflag.NewGroup(nil, "xlog")
+	logSeverityFlag = cflag.String(flagGroup, "severity", "NOTICE",
+		"Log severity")
+	loggers []*phuslog.CategorizedLogger
+)
+
+func New(category string) *phuslog.CategorizedLogger {
+	logger := phuslog.DefaultLogger.Categorized(category)
+	loggers = append(loggers, logger)
+	return logger
+}
+
+func Init() {
+	level, ok := parseSeverity(logSeverityFlag.Value())
+	if !ok {
+		return
+	}
+
+	phuslog.DefaultLogger.SetLevel(level)
+	for _, logger := range loggers {
+		logger.SetLevel(level)
+	}
+}
+
+func parseSeverity(severity string) (phuslog.Level, bool) {
+	switch strings.ToUpper(strings.TrimSpace(severity)) {
+	case "TRACE":
+		return phuslog.TraceLevel, true
+	case "DEBUG":
+		return phuslog.DebugLevel, true
+	case "INFO":
+		return phuslog.InfoLevel, true
+	case "NOTICE", "WARN":
+		return phuslog.WarnLevel, true
+	case "ERROR":
+		return phuslog.ErrorLevel, true
+	case "CRITICAL", "ALERT", "EMERGENCY":
+		return phuslog.FatalLevel, true
+	default:
+		return 0, false
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"path/filepath"
 
-	"github.com/hlandau/dexlogconfig"
+	"github.com/namecoin/ncdns/logconfig"
 	"github.com/namecoin/ncdns/server"
 	"gopkg.in/hlandau/easyconfig.v1"
 	"gopkg.in/hlandau/service.v2"
@@ -16,7 +16,7 @@ func main() {
 		ProgramName: "ncdns",
 	}
 	config.ParseFatal(&cfg)
-	dexlogconfig.Init()
+	logconfig.Init()
 
 	// We use the configPath to resolve paths relative to the config file.
 	cfg.ConfigDir = filepath.Dir(config.ConfigFilePath())

--- a/ncdumpzone/ncdumpzone.go
+++ b/ncdumpzone/ncdumpzone.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"strings"
 
-	"github.com/hlandau/xlog"
 	"github.com/miekg/dns"
 
 	"github.com/namecoin/ncbtcjson"
+	"github.com/namecoin/ncdns/logconfig"
 	"github.com/namecoin/ncdns/namecoin"
 	"github.com/namecoin/ncdns/ncdomain"
 	"github.com/namecoin/ncdns/rrtourl"
@@ -16,7 +16,7 @@ import (
 	"github.com/namecoin/ncdns/util"
 )
 
-var log, Log = xlog.New("ncdumpzone")
+var log = logconfig.New("ncdumpzone")
 
 const defaultPerCall uint32 = 1000
 
@@ -69,7 +69,9 @@ func dumpName(item *ncbtcjson.NameShowResult, conn *namecoin.Client,
 	}
 
 	rrs, err := value.RRsRecursive(nil, suffix+".bit.", "bit.")
-	log.Warne(err, "error generating RRs")
+	if err != nil {
+		log.Warn().Err(err).Msg("error generating RRs")
+	}
 
 	for _, rr := range rrs {
 		err = dumpRR(rr, dest, format)
@@ -100,7 +102,7 @@ func Dump(conn *namecoin.Client, dest io.Writer, format string) error {
 		}
 
 		if len(results) <= continuing {
-			log.Info("out of results, stopping")
+			log.Info().Msg("out of results, stopping")
 			break
 		}
 
@@ -129,11 +131,11 @@ func Dump(conn *namecoin.Client, dest io.Writer, format string) error {
 			// All of the results had a nameError but we're
 			// at the end of the results, so not a problem.
 			if lenResults < int(perCall)-1 {
-				log.Info("out of results, stopping")
+				log.Info().Msg("out of results, stopping")
 				break
 			}
 
-			log.Warnf("All %d results (start point %s) had a NameError", lenResults, currentName)
+			log.Warn().Msgf("All %d results (start point %s) had a NameError", lenResults, currentName)
 			perCall *= 2
 			continue
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -11,15 +11,15 @@ import (
 
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/hlandau/buildinfo"
-	"github.com/hlandau/xlog"
 	"github.com/miekg/dns"
 	madns "gopkg.in/hlandau/madns.v2"
 
 	"github.com/namecoin/ncdns/backend"
+	"github.com/namecoin/ncdns/logconfig"
 	"github.com/namecoin/ncdns/namecoin"
 )
 
-var log, Log = xlog.New("ncdns.server")
+var log = logconfig.New("ncdns.server")
 
 type Server struct {
 	cfg Config
@@ -215,7 +215,9 @@ func (s *Server) loadKey(fn, privateFn string) (k *dns.DNSKEY, privatek crypto.P
 	}
 
 	privatek, err = k.ReadPrivateKey(privatef, privateFn)
-	log.Fatale(err)
+	if err != nil {
+		log.Fatal().Err(err).Msg("")
+	}
 
 	return
 }
@@ -225,14 +227,16 @@ func (s *Server) Start() error {
 	s.udpServer = s.runListener("udp")
 	s.tcpServer = s.runListener("tcp")
 	s.wgStart.Wait()
-	log.Info("Listeners started")
+	log.Info().Msg("Listeners started")
 
 	return s.StartBackgroundTasks()
 }
 
 func (s *Server) doRunListener(ds *dns.Server) {
 	err := ds.ActivateAndServe()
-	log.Fatale(err)
+	if err != nil {
+		log.Fatal().Err(err).Msg("")
+	}
 }
 
 func (s *Server) runListener(net string) *dns.Server {

--- a/server/web.go
+++ b/server/web.go
@@ -96,7 +96,9 @@ func (ws *webServer) layoutInfo() *layoutInfo {
 
 func (ws *webServer) handleRoot(rw http.ResponseWriter, req *http.Request) {
 	err := mainPageTpl.Execute(rw, ws.layoutInfo())
-	log.Infoe(err, "tpl")
+	if err != nil {
+		log.Info().Err(err).Msg("tpl")
+	}
 }
 
 func (ws *webServer) handleLookup(rw http.ResponseWriter, req *http.Request) {
@@ -124,7 +126,9 @@ func (ws *webServer) handleLookup(rw http.ResponseWriter, req *http.Request) {
 
 	defer func() {
 		err := lookupPageTpl.Execute(rw, &info)
-		log.Infoe(err, "lookup page tpl")
+		if err != nil {
+			log.Info().Err(err).Msg("lookup page tpl")
+		}
 	}()
 
 	q := req.FormValue("q")
@@ -216,7 +220,9 @@ func webStart(listenAddr string, server *Server) error {
 
 	go func() {
 		err := s.ListenAndServe()
-		log.Errore(err, "HTTP server")
+		if err != nil {
+			log.Error().Err(err).Msg("HTTP server")
+		}
 	}()
 	return nil
 }

--- a/tlshook/tlshook.go
+++ b/tlshook/tlshook.go
@@ -4,19 +4,19 @@
 package tlshook
 
 import (
-	"github.com/hlandau/xlog"
+	"github.com/namecoin/ncdns/logconfig"
 	"github.com/namecoin/ncdns/ncdomain"
 )
 
-var log, Log = xlog.New("ncdns.tlshook")
+var log = logconfig.New("ncdns.tlshook")
 
 func DomainValueHookTLS(qname string, ncv *ncdomain.Value) (err error) {
 
-	log.Info("Intercepted a Value for ", qname)
+	log.Info().Msgs("Intercepted a Value for ", qname)
 	if protocol, ok := ncv.Map["_tcp"]; ok { // TODO: look into allowing non-TCP protocols
-		log.Info("Saw a request with TCP")
+		log.Info().Msg("Saw a request with TCP")
 		if _, ok := protocol.Map["_443"]; ok { // TODO: check all ports, not just 443
-			log.Info("Saw a request with TCP port 443")
+			log.Info().Msg("Saw a request with TCP port 443")
 
 			// TODO: maybe find something to do here?
 			// We used to do dehydrated certificate injection here, but that's ancient.

--- a/tlsoverridefirefox/tlsoverridefirefoxsync/firefoxoverridesync.go
+++ b/tlsoverridefirefox/tlsoverridefirefoxsync/firefoxoverridesync.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hlandau/xlog"
 	"gopkg.in/hlandau/easyconfig.v1/cflag"
 
+	"github.com/namecoin/ncdns/logconfig"
 	"github.com/namecoin/ncdns/namecoin"
 	"github.com/namecoin/ncdns/ncdumpzone"
 	"github.com/namecoin/ncdns/tlsoverridefirefox"
@@ -25,7 +25,7 @@ var (
 		"Firefox profile directory")
 )
 
-var log, Log = xlog.New("ncdns.tlsoverridefirefoxsync")
+var log = logconfig.New("ncdns.tlsoverridefirefoxsync")
 
 var zoneData string
 var zoneDataReady = false
@@ -42,7 +42,9 @@ func watchZone(conn *namecoin.Client) {
 		var result bytes.Buffer
 
 		err := ncdumpzone.Dump(conn, &result, "firefox-override")
-		log.Fatale(err, "Couldn't dump zone for Firefox override sync")
+		if err != nil {
+			log.Fatal().Err(err).Msg("Couldn't dump zone for Firefox override sync")
+		}
 
 		zoneDataMux.Lock()
 		zoneData = result.String()
@@ -55,7 +57,7 @@ func watchZone(conn *namecoin.Client) {
 
 func watchProfile(suffix string) {
 	if firefoxProfileDirFlag.Value() == "" {
-		log.Fatal("Missing required config option tlsoverridefirefox.profiledir")
+		log.Fatal().Msg("Missing required config option tlsoverridefirefox.profiledir")
 	}
 
 	for {
@@ -76,7 +78,7 @@ func watchProfile(suffix string) {
 			continue
 		}
 
-		log.Debug("Syncing zone to cert_override.txt...")
+		log.Debug().Msg("Syncing zone to cert_override.txt...")
 
 		prevOverrides, err := ioutil.ReadFile(
 			firefoxProfileDirFlag.Value() + "/cert_override.txt")
@@ -89,15 +91,16 @@ func watchProfile(suffix string) {
 				// read an empty file.
 				prevOverrides = []byte(``)
 			} else {
-				log.Fatale(err,
-					"Couldn't read Firefox "+
-						"cert_override.txt")
+				log.Fatal().Err(err).Msg("Couldn't read Firefox " +
+					"cert_override.txt")
 			}
 		}
 
 		filteredPrevOverrides, err := tlsoverridefirefox.
 			FilterOverrides(string(prevOverrides), suffix)
-		log.Fatale(err, "Couldn't filter Firefox overrides")
+		if err != nil {
+			log.Fatal().Err(err).Msg("Couldn't filter Firefox overrides")
+		}
 
 		newOverrides := filteredPrevOverrides + zoneDataLocal + "\n"
 
@@ -105,9 +108,11 @@ func watchProfile(suffix string) {
 		// TODO: maybe instead write to a temp file and then move the file into place?
 		err = ioutil.WriteFile(firefoxProfileDirFlag.Value()+
 			"/cert_override.txt", []byte(newOverrides), 0600)
-		log.Fatale(err, "Couldn't write Firefox cert_override.txt")
+		if err != nil {
+			log.Fatal().Err(err).Msg("Couldn't write Firefox cert_override.txt")
+		}
 
-		log.Debug("Finished syncing zone to cert_override.txt")
+		log.Debug().Msg("Finished syncing zone to cert_override.txt")
 
 		time.Sleep(10 * time.Minute)
 	}
@@ -117,7 +122,9 @@ func profileInUse() bool {
 	// This glob pattern matches the ".sqlite-wal" and ".sqlite-shm" files
 	// that are only present when Firefox's databases are open.
 	matches, err := filepath.Glob(firefoxProfileDirFlag.Value() + "/*.sqlite-*")
-	log.Fatale(err, "Couldn't check if Firefox is running for override sync")
+	if err != nil {
+		log.Fatal().Err(err).Msg("Couldn't check if Firefox is running for override sync")
+	}
 
 	return matches != nil
 }


### PR DESCRIPTION
This switches ncdns logging from xlog/dexlogconfig to phuslog now that phuslog supports gccgo. It keeps the same log categories and preserves the old xlog behavior where nil errors are ignored. 
Logs are now phuslog JSON, Fatal uses phuslog normal exit code 255, and old [xlog] config no longer applies; ncprop279 still builds, but its xlog severity setting no longer controls ncdns logs. 
Tested normal, no-TLS, Windows, and gccgo 14 builds/tests, including ncdns, ncdt, and ncdumpzone.